### PR TITLE
feat: enable support for OpenSCAD lazy-union

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-openscad-preview",
-  "version": "0.1.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-openscad-preview",
-      "version": "0.1.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@lit/context": "^1.1.6",
@@ -19,9 +19,9 @@
       "devDependencies": {
         "@changesets/cli": "^2.30.0",
         "@eslint/js": "^10.0.1",
-        "@types/node": "^25.x",
+        "@types/node": "^25.0",
         "@types/three": "^0.183.1",
-        "@types/vscode": "^1.109.0",
+        "@types/vscode": "^1.105.1",
         "@types/vscode-webview": "^1.57.5",
         "esbuild": "^0.27.3",
         "eslint": "^10.0.2",
@@ -33,7 +33,7 @@
         "vscode-test": "^1.6.1"
       },
       "engines": {
-        "vscode": "^1.80.0"
+        "vscode": "^1.105.1"
       }
     },
     "node_modules/@babel/runtime": {
@@ -1230,7 +1230,6 @@
       "integrity": "sha512-RpV6r/ij22zRRdyBPcxDeKAzH43phWVKEjL2iksqo1Vz3CuBUrgmPpPhALKiRfU7OMCmeeO9vECBMsV0hMTG8Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1317,7 +1316,6 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -1572,8 +1570,7 @@
       "version": "0.0.44",
       "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.44.tgz",
       "integrity": "sha512-F7qPRumUK3EHjNdopfICLGRf3iNPoZQt+McTHAn4AlOWPB3W2kL4H0S7uqEqbyZ6rCxaeDjpAn3MCUnwTu/VJQ==",
-      "license": "CC-BY-4.0",
-      "peer": true
+      "license": "CC-BY-4.0"
     },
     "node_modules/@webgpu/types": {
       "version": "0.1.69",
@@ -1588,7 +1585,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1954,7 +1950,6 @@
       "integrity": "sha512-uYixubwmqJZH+KLVYIVKY1JQt7tysXhtj21WSvjcSmU5SVNzMus1bgLe+pAt816yQ8opKfheVVoPLqvVMGejYw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -2660,7 +2655,6 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -3056,7 +3050,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3537,7 +3530,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@changesets/cli": "^2.30.0",
     "@eslint/js": "^10.0.1",
-    "@types/node": "^25.x",
+    "@types/node": "^25.0",
     "@types/three": "^0.183.1",
     "@types/vscode": "^1.105.1",
     "@types/vscode-webview": "^1.57.5",
@@ -76,6 +76,11 @@
           "type": "string",
           "default": "",
           "description": "Path to the OpenSCAD executable. Leave empty to use automatic detection or the system PATH."
+        },
+        "openscad.enableLazyUnion": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable lazy unions, creating a multi-part exported object."
         }
       }
     },

--- a/src/extension/services/ScadClient.ts
+++ b/src/extension/services/ScadClient.ts
@@ -51,6 +51,14 @@ export class ScadClient {
     return "openscad";
   }
 
+  private static get enableLazyUnion(): string[] {
+    const setting = workspace
+      .getConfiguration("openscad")
+      .get<boolean>("enableLazyUnion", false);
+
+    return setting ? ["--enable", "lazy-union"] : [];
+  }
+
   public static async render(
     scadPath: string,
     parameters: Record<string, string | number | boolean> = {},
@@ -79,6 +87,7 @@ export class ScadClient {
       const process = spawn(ScadClient.executablePath, [
         "--export-format",
         format,
+        ...this.enableLazyUnion,
         "-o",
         tmpFile,
         ...paramArgs,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,9 @@
       "ES2020",
       "DOM"
     ],
+    "types": [
+      "node"
+    ],
     "sourceMap": true,
     "rootDir": "src",
     "strict": true,


### PR DESCRIPTION
# Description

Adds support for OpenSCAD's lazy-union, which enables objects to be exported as an hierarchically multi-part structure.

# Motivation

Modeling for colored 3D-printing is easier when your solid is built by multiple parts. That way, in slicers such as BambuStudio, you can select which objects will be printed in which colors and move along with your print. As the extension can send to printer directly, it would be nice to have a way to have multi-part objects while rendering to send it over to my slicer of choice.

# Decisions

* As OpenSCAD gives lazy-union as a global setting, I added it as a global setting for the extension as well. 
* I defaulted this new setting as false to maintain default behavior and avoid potential breaking changes if this is a config users may not have in their builds of OpenSCAD.

# Examples

| <img width="1912" height="1241" alt="image" src="https://github.com/user-attachments/assets/779c674e-4f02-4a02-93f9-8fdaa111610c" /> |
| --- |
| .scad with red disk inside unset grey disc |

| <img width="668" height="236" alt="image" src="https://github.com/user-attachments/assets/b9dd62d7-e522-4ac7-b51b-b0e0fd7132ff" /> |
| --- |
| Lazy Union setting enabled |

| <img width="558" height="162" alt="image" src="https://github.com/user-attachments/assets/43476d51-2465-49eb-bae3-3e22abc6cd3e" /> |
| --- |
| BambuStudio now recognizes that there's a multi-part object file |

| <img width="1719" height="1241" alt="image" src="https://github.com/user-attachments/assets/dcd8429f-a461-4c28-967a-e93ad95cabc0" /> |
| --- |
| Color is manually defined on Bambu (this is always like that, chosen colors was on purpose for this sample) |

| <img width="1787" height="982" alt="image" src="https://github.com/user-attachments/assets/d45a5de4-c1af-4db0-9f23-a16a3ae54474" /> |
| --- |
| Opening exported file over fusion, we can see the parts on the assemble |


