### PR TITLE
fix: wrap string params in quotes to properly render updated fields

### DIFF
--- a/src/extension/services/ScadClient.ts
+++ b/src/extension/services/ScadClient.ts
@@ -73,6 +73,11 @@ export class ScadClient {
 
       const paramArgs: string[] = [];
       for (const [name, value] of Object.entries(parameters)) {
+        if (typeof value === "string") {
+          paramArgs.push("-D", `${name}="${value}"`);
+          continue;
+        }
+
         paramArgs.push("-D", `${name}=${value}`);
       }
 


### PR DESCRIPTION
# Description

Fix behavior on issue #35, on which string parameters weren't properly updating it.

# Demo
<video src="https://github.com/user-attachments/assets/0f816f23-9e9d-4217-bd10-48f1d570ef57"></video>

