### PR TITLE
fix: rendering errors from bad param validation; fix logging output

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,14 +2,17 @@
   "version": "2.0.0",
   "tasks": [
     {
-      "type": "npm",
-      "script": "compile",
+      "type": "shell",
+      "command": "npm --prefix '${workspaceFolder}' run compile",
       "group": {
         "kind": "build",
         "isDefault": true
       },
       "label": "npm: compile",
       "detail": "Compile extension and webview",
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
       "problemMatcher": {
         "owner": "esbuild",
         "pattern": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # vscode-openscad-preview
 
+## 0.6.1
+
+### Patch Changes
+
+- Fix expression-valued variables (e.g. `shelf_depth = a + b + c`) being treated as customizer parameters and passed as quoted string `-D` arguments to OpenSCAD. These variables are now skipped by the parser and computed by OpenSCAD from the source file as intended. This was the root cause of some render failures.
+- Render errors are now propagated to the VS Code UI: the loading spinner clears on failure, an error notification appears with a "Show Output" action, and the full OpenSCAD stderr output is forwarded to the Output panel for this extension.
+- All OpenSCAD stderr is now streamed to the Output channel immediately as it arrives, not only on failure. The full command is also logged before each render.
+- Fixed a double-render on startup caused by the file watcher firing both an `add` event and an explicit read simultaneously, resulting in the first render being immediately cancelled.
+- Fixed cancelled renders on Windows being surfaced as errors rather than being silently discarded.
+
 ## 0.6.0
 
 ### Minor Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-openscad-preview",
-  "version": "0.5.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-openscad-preview",
-      "version": "0.5.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@lit/context": "^1.1.6",
@@ -21,16 +21,16 @@
         "@eslint/js": "^10.0.1",
         "@types/node": "^25.6.0",
         "@types/three": "^0.184.0",
-        "@types/vscode": "^1.118.0",
+        "@types/vscode": "^1.120.0",
         "@types/vscode-webview": "^1.57.5",
+        "@vscode/test-electron": "^2.5.2",
         "esbuild": "^0.28.0",
         "eslint": "^10.3.0",
         "jiti": "^2.7.0",
         "prettier": "^3.8.3",
         "tsx": "^4.21.0",
         "typescript": "^6.0.3",
-        "typescript-eslint": "^8.59.2",
-        "vscode-test": "^1.6.1"
+        "typescript-eslint": "^8.59.2"
       },
       "engines": {
         "vscode": "^1.105.1"
@@ -824,9 +824,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1187,15 +1187,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@tootallnate/once": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/@tweenjs/tween.js": {
       "version": "23.1.3",
       "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
@@ -1262,9 +1253,9 @@
       "license": "MIT"
     },
     "node_modules/@types/vscode": {
-      "version": "1.118.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.118.0.tgz",
-      "integrity": "sha512-Ah6eTlqDcwIMELEVwQMO++rJAFBRz/oLluLD/vWdYrH1KuI9kfpaM+7pg0OvvascgcJy+ghLCERAYouM4QbzGw==",
+      "version": "1.120.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.120.0.tgz",
+      "integrity": "sha512-feaT4Rst+FkTch5zz/ZbNCxoIvo55YU80Be2kiL7OJcod4+CUYf2lUBPdIJzozNnSEMq1VRTGrWEcCGFB3fBmA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1479,9 +1470,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1581,6 +1572,23 @@
       "integrity": "sha512-1KAZ7XCMagp5Gdrlr4bbbcAqgcIL623iO1wW6rfcSVGAVUQvR0WP7bQx1SbJ11gmV3fdQTSEFIJQ/5C+HuVasw==",
       "license": "CC-BY-4.0"
     },
+    "node_modules/@vscode/test-electron": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.5.2.tgz",
+      "integrity": "sha512-8ukpxv4wYe0iWMRQU18jhzJOHkeGKbnw7xWRX3Zw1WJA4cEKbHcmmLPdPrPtL6rhDcrlCZN+xKRpv09n4gRHYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "jszip": "^3.10.1",
+        "ora": "^8.1.0",
+        "semver": "^7.6.2"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1605,15 +1613,13 @@
       }
     },
     "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "dev": true,
-      "dependencies": {
-        "debug": "4"
-      },
+      "license": "MIT",
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -1670,12 +1676,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
-    },
     "node_modules/better-path-resolve": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/better-path-resolve/-/better-path-resolve-1.0.0.tgz",
@@ -1689,45 +1689,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/big-integer": {
-      "version": "1.6.52",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
-      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
-    "node_modules/binary": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
-      "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
-      "dev": true,
-      "dependencies": {
-        "buffers": "~0.1.1",
-        "chainsaw": "~0.1.0"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/bluebird": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
-      "dev": true
-    },
-    "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "node_modules/braces": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
@@ -1739,36 +1700,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/buffer-indexof-polyfill": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
-      "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/buffers": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-      "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.2.0"
-      }
-    },
-    "node_modules/chainsaw": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
-      "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
-      "dev": true,
-      "dependencies": {
-        "traverse": ">=0.3.0 <0.4"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/chardet": {
@@ -1793,17 +1724,41 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -1866,15 +1821,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/duplexer2": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
-      "dev": true,
-      "dependencies": {
-        "readable-stream": "^2.0.2"
       }
     },
     "node_modules/enquirer": {
@@ -2045,9 +1991,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2310,9 +2256,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -2331,12 +2277,6 @@
         "node": ">=6 <7 || >=8"
       }
     },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2352,33 +2292,17 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/fstream": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
-      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
-      "deprecated": "This package is no longer supported.",
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
       "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "inherits": "~2.0.0",
-        "mkdirp": ">=0.5 0",
-        "rimraf": "2"
-      },
+      "license": "MIT",
       "engines": {
-        "node": ">=0.6"
-      }
-    },
-    "node_modules/fstream/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
+        "node": ">=18"
       },
-      "bin": {
-        "rimraf": "bin.js"
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-tsconfig": {
@@ -2392,27 +2316,6 @@
       },
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
-      }
-    },
-    "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob-parent": {
@@ -2456,30 +2359,31 @@
       "dev": true
     },
     "node_modules/http-proxy-agent": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
-      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@tootallnate/once": "1",
-        "agent-base": "6",
-        "debug": "4"
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
     },
     "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "agent-base": "6",
+        "agent-base": "^7.1.2",
         "debug": "4"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
     },
     "node_modules/human-id": {
@@ -2519,6 +2423,13 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -2529,22 +2440,12 @@
         "node": ">=0.8.19"
       }
     },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "dev": true,
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -2565,6 +2466,19 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-number": {
@@ -2604,7 +2518,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -2667,6 +2582,19 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "dev": true,
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -2691,11 +2619,15 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/listenercount": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
-      "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
-      "dev": true
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
     },
     "node_modules/lit": {
       "version": "3.3.2",
@@ -2782,38 +2714,17 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
       "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
+      "license": "MIT",
       "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.6"
+        "node": ">=18"
       },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mri": {
@@ -2840,13 +2751,20 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "wrappy": "1"
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/optionator": {
@@ -2865,6 +2783,140 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/ora": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
+      "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "cli-cursor": "^5.0.0",
+        "cli-spinners": "^2.9.2",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^2.0.0",
+        "log-symbols": "^6.0.0",
+        "stdin-discarder": "^0.2.2",
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ora/node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/log-symbols": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
+      "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "is-unicode-supported": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/log-symbols/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/outdent": {
@@ -2949,6 +3001,13 @@
         "quansync": "^0.2.7"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true,
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -2957,15 +3016,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -3048,7 +3098,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -3143,6 +3194,7 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -3157,7 +3209,8 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/readdirp": {
       "version": "5.0.0",
@@ -3192,6 +3245,23 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -3201,22 +3271,6 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/run-parallel": {
@@ -3267,7 +3321,8 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -3333,11 +3388,25 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/stdin-discarder": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
+      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -3346,7 +3415,8 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
@@ -3449,15 +3519,6 @@
       },
       "engines": {
         "node": ">=8.0"
-      }
-    },
-    "node_modules/traverse": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
-      "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
-      "dev": true,
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/ts-api-utils": {
@@ -4045,24 +4106,6 @@
         "node": ">= 4.0.0"
       }
     },
-    "node_modules/unzipper": {
-      "version": "0.10.14",
-      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.14.tgz",
-      "integrity": "sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==",
-      "dev": true,
-      "dependencies": {
-        "big-integer": "^1.6.17",
-        "binary": "~0.3.0",
-        "bluebird": "~3.4.1",
-        "buffer-indexof-polyfill": "~1.0.0",
-        "duplexer2": "~0.1.4",
-        "fstream": "^1.0.12",
-        "graceful-fs": "^4.2.2",
-        "listenercount": "~1.0.1",
-        "readable-stream": "~2.3.6",
-        "setimmediate": "~1.0.4"
-      }
-    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -4077,23 +4120,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
-    },
-    "node_modules/vscode-test": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.6.1.tgz",
-      "integrity": "sha512-086q88T2ca1k95mUzffvbzb7esqQNvJgiwY4h29ukPhFo8u+vXOOmelUoU5EQUHs3Of8+JuQ3oGdbVCqaxuTXA==",
-      "deprecated": "This package has been renamed to @vscode/test-electron, please update to the new name",
       "dev": true,
-      "dependencies": {
-        "http-proxy-agent": "^4.0.1",
-        "https-proxy-agent": "^5.0.0",
-        "rimraf": "^3.0.2",
-        "unzipper": "^0.10.11"
-      },
-      "engines": {
-        "node": ">=8.9.3"
-      }
+      "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -4120,12 +4148,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "OpenSCAD Preview",
   "description": "An interactive 3D preview environment for OpenSCAD (.scad) files.",
   "publisher": "thijsdaniels",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "icon": "icon.png",
   "author": "Thijs Daniels",
   "license": "MIT",
@@ -14,8 +14,8 @@
   "type": "module",
   "scripts": {
     "vscode:prepublish": "npm run package",
-    "compile": "node ./esbuild.ts",
-    "package": "NODE_ENV=production node ./esbuild.ts",
+    "compile": "tsx ./esbuild.ts",
+    "package": "NODE_ENV=production tsx ./esbuild.ts",
     "watch": "npm run compile -- --watch",
     "pretest": "npm run compile && npm run lint",
     "lint": "eslint src --ext ts",
@@ -40,16 +40,16 @@
     "@eslint/js": "^10.0.1",
     "@types/node": "^25.6.0",
     "@types/three": "^0.184.0",
-    "@types/vscode": "^1.105.1",
+    "@types/vscode": "^1.120.0",
     "@types/vscode-webview": "^1.57.5",
+    "@vscode/test-electron": "^2.5.2",
     "esbuild": "^0.28.0",
     "eslint": "^10.3.0",
     "jiti": "^2.7.0",
     "prettier": "^3.8.3",
     "tsx": "^4.21.0",
     "typescript": "^6.0.3",
-    "typescript-eslint": "^8.59.2",
-    "vscode-test": "^1.6.1"
+    "typescript-eslint": "^8.59.2"
   },
   "engines": {
     "vscode": "^1.105.1"

--- a/src/extension/core/ScadSession.ts
+++ b/src/extension/core/ScadSession.ts
@@ -35,23 +35,17 @@ export class ScadSession {
   private _onRenderStarted = new EventEmitter<void>();
   public readonly onRenderStarted = this._onRenderStarted.event;
 
+  private _onRenderError = new EventEmitter<Error>();
+  public readonly onRenderError = this._onRenderError.event;
+
   private _onLog = new EventEmitter<string>();
   public readonly onLog = this._onLog.event;
 
-  /**
-   * @todo The session lifecycle isn't as clean as it could be. For example,
-   * it shouldn't be necessary to fire the onParametersUpdated event from the
-   * scadWatcher.onChange callback, because that callback is already updating
-   * the parameters, which _should_ trigger the scadParameters.onChange
-   * callback, but it currently doesn't. When it does, we should make sure we
-   * don't render twice, because the scadParameters.onChange callback already
-   * triggers a render as well. Perhaps the lifecycle itself is OK, but just not
-   * very clearly laid out.
-   */
   constructor(public readonly documentUri: Uri) {
     this.scadRenderer = new ScadRenderer({
       onStart: () => this._onRenderStarted.fire(),
       onComplete: (data) => this._onRenderCompleted.fire(data),
+      onError: (err) => this._onRenderError.fire(err),
       onLog: (chunk) => this._onLog.fire(chunk),
     });
 
@@ -224,6 +218,7 @@ export class ScadSession {
     this.jsonWatcher?.close();
     this._onRenderStarted.dispose();
     this._onRenderCompleted.dispose();
+    this._onRenderError.dispose();
     this._onParametersChanged.dispose();
   }
 }

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -1,23 +1,17 @@
-import { ExtensionContext, window } from "vscode";
+import { ExtensionContext } from "vscode";
 import { registerShowPanelCommand } from "./commands/showPanel";
 import { ScadSessionManager } from "./core/ScadSessionManager";
+import { ScadClient } from "./services/ScadClient";
 
 let sessionManager: ScadSessionManager | undefined;
 
 export function activate(context: ExtensionContext) {
-  // 1. Initialize global utilities (Dependency Injection roots)
-  const logger = window.createOutputChannel("OpenSCAD Preview");
-  context.subscriptions.push(logger);
+  context.subscriptions.push(ScadClient.outputChannel);
 
-  // 3. Create the centralized Session Manager
   sessionManager = new ScadSessionManager();
 
-  // 4. Register Commands
   const showPanelDisposable = registerShowPanelCommand(context, sessionManager);
   context.subscriptions.push(showPanelDisposable);
-
-  // Additional future features (HoverProviders, Formatters) can be registered here
-  // and provided the sessionManager if they need access to parsed parameters!
 }
 
 export function deactivate() {

--- a/src/extension/services/ScadClient.ts
+++ b/src/extension/services/ScadClient.ts
@@ -4,7 +4,7 @@ import { readFile, unlink } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
 import { platform } from "process";
-import { workspace } from "vscode";
+import { window, workspace } from "vscode";
 import { ModelFormat } from "../../shared/types/ModelFormat";
 
 const platformDefaults: Record<string, string[]> = {
@@ -27,6 +27,8 @@ export class ScadClient {
     string,
     ChildProcessWithoutNullStreams
   >();
+
+  public static readonly outputChannel = window.createOutputChannel("OpenSCAD Preview");
 
   private static _executablePath: string | undefined;
 
@@ -67,8 +69,8 @@ export class ScadClient {
     format: ModelFormat = ModelFormat.ThreeMF,
     onStderr?: (chunk: string) => void,
   ): Promise<Buffer> {
-    // Kill any currently running process for this file to prevent runway spawn leaks
-    // when sliders emit rapid updates
+    // Kill any currently running process for this file to prevent runaway
+    // spawn leaks when sliders emit rapid updates.
     const existingProcess = this.activeProcesses.get(scadPath);
     if (existingProcess) {
       existingProcess.kill();
@@ -91,7 +93,8 @@ export class ScadClient {
         paramArgs.push("-D", `${name}=${value}`);
       }
 
-      const process = spawn(ScadClient.executablePath, [
+      const execPath = ScadClient.executablePath;
+      const args = [
         "--export-format",
         format,
         ...this.enableLazyUnion,
@@ -99,36 +102,54 @@ export class ScadClient {
         tmpFile,
         ...paramArgs,
         scadPath,
-      ]);
+      ];
+
+      this.outputChannel.appendLine(`[OpenSCAD] Running: ${execPath} ${args.join(" ")}`);
+
+      const process = spawn(execPath, args);
 
       this.activeProcesses.set(scadPath, process);
 
+      let stderrBuffer = "";
+
       process.stderr.on("data", (data) => {
+        const chunk = data.toString();
+        stderrBuffer += chunk;
+        // Always log to the output channel so the user can see OpenSCAD errors
+        // regardless of whether the webview is ready.
+        this.outputChannel.append(chunk);
         if (onStderr) {
-          onStderr(data.toString());
+          onStderr(chunk);
         }
       });
 
       process.on("close", async (code, signal) => {
-        this.activeProcesses.delete(scadPath);
+        // Only clean up the map entry if it still points to this process.
+        // A newer render may have already replaced it; blindly deleting would
+        // remove the active process and break subsequent cancellation.
+        if (this.activeProcesses.get(scadPath) === process) {
+          this.activeProcesses.delete(scadPath);
+        }
 
-        // If process was killed gracefully by our cancellation, cleanly reject error
-        if (signal === "SIGTERM") {
+        // If process was killed gracefully by our cancellation, reject cleanly.
+        if (signal === "SIGTERM" || (platform === "win32" && signal === null && code === 1 && stderrBuffer === "")) {
           reject(new Error("Render cancelled"));
           return;
         }
 
         if (code !== 0) {
-          const errorMsg = `OpenSCAD process exited with code ${code}`;
-          reject(new Error(errorMsg));
+          const detail = stderrBuffer.trim() ? `\n${stderrBuffer.trim()}` : "";
+          this.outputChannel.appendLine(`[OpenSCAD] Process exited with code ${code}${detail ? "" : " (no stderr output)"}`);
+          reject(new Error(`OpenSCAD process exited with code ${code}${detail}`));
           return;
         }
 
         try {
           const buffer = await readFile(tmpFile);
+          this.outputChannel.appendLine(`[OpenSCAD] Render complete: ${tmpFile}`);
           resolve(buffer);
         } catch (err) {
-          reject(new Error(`Failed to read temporary 3MF file: ${err}`));
+          reject(new Error(`Failed to read temporary output file: ${err}`));
         } finally {
           // Clean up the temp file
           try {
@@ -140,9 +161,12 @@ export class ScadClient {
       });
 
       process.on("error", (err) => {
-        this.activeProcesses.delete(scadPath);
-        const errorMsg = `Failed to start OpenSCAD: ${err}`;
-        reject(new Error(errorMsg));
+        if (this.activeProcesses.get(scadPath) === process) {
+          this.activeProcesses.delete(scadPath);
+        }
+        const msg = `Failed to start OpenSCAD: ${err.message}\nExecutable path: ${execPath}`;
+        this.outputChannel.appendLine(`[OpenSCAD] ${msg}`);
+        reject(new Error(msg));
       });
     });
   }

--- a/src/extension/services/ScadParser.test.ts
+++ b/src/extension/services/ScadParser.test.ts
@@ -77,6 +77,30 @@ test("ScadParser - extracts parameters successfully", () => {
   ]);
 });
 
+test("ScadParser - skips expression-valued variables", () => {
+  const scadContent = `
+    // Literal values — these should be included
+    full_width = 254;
+    surface_thickness = 3.5;
+    label = "default";
+
+    // Expression values — these must be skipped so OpenSCAD computes them
+    shelf_depth = device_depth + surface_thickness + width_extra_clearance;
+    inner_width_w_clearance = device_width + width_extra_clearance;
+    second_screw_height = screw_step_height + first_screw_height;
+    side_panel_shape = rect([side_panel_height, side_panel_depth]);
+    back_blocks = [[40, 80]];
+  `;
+
+  const parser = new ScadParser(scadContent);
+
+  assert.deepStrictEqual(parser.parameters, [
+    { name: "full_width", type: "number", group: undefined, value: 254 },
+    { name: "surface_thickness", type: "number", group: undefined, value: 3.5 },
+    { name: "label", type: "string", group: undefined, value: "default" },
+  ]);
+});
+
 test("ScadParser - handles malformed contents defensively", () => {
   const scadContent = `
     /* [Weird Stuff] */

--- a/src/extension/services/ScadParser.ts
+++ b/src/extension/services/ScadParser.ts
@@ -55,6 +55,11 @@ export class ScadParser {
 
       const parsedVal = this.parseVariableValue(decl.valueStr);
 
+      // Expression-valued variables (not literal booleans, numbers, or quoted
+      // strings) are computed by OpenSCAD from the file — skip them here so
+      // they are never overridden via -D with a wrong string value.
+      if (!parsedVal) continue;
+
       // We construct the object in a type-safe way before applying to partial
       const param: Partial<ScadParameter> = {
         name: decl.name,
@@ -95,18 +100,28 @@ export class ScadParser {
   private parseVariableValue(valueStr: string): {
     type: "number" | "boolean" | "string";
     value: string | number | boolean;
-  } {
+  } | null {
     const trimmed = valueStr.trim();
+
     if (trimmed === "true" || trimmed === "false") {
       return { type: "boolean", value: trimmed === "true" };
-    } else if (trimmed !== "" && !isNaN(Number(trimmed))) {
-      return { type: "number", value: Number(trimmed) };
-    } else {
-      return {
-        type: "string",
-        value: trimmed.replace(/^["']|["']$/g, ""),
-      };
     }
+
+    if (trimmed !== "" && !isNaN(Number(trimmed))) {
+      return { type: "number", value: Number(trimmed) };
+    }
+
+    // Only accept explicitly quoted string literals. Bare expressions
+    // (arithmetic, function calls, vectors, variable references) return null
+    // so the caller can skip them — OpenSCAD computes those itself.
+    if (
+      (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+      (trimmed.startsWith("'") && trimmed.endsWith("'"))
+    ) {
+      return { type: "string", value: trimmed.slice(1, -1) };
+    }
+
+    return null;
   }
 
   private parseChoices(

--- a/src/extension/services/ScadRenderer.ts
+++ b/src/extension/services/ScadRenderer.ts
@@ -9,22 +9,28 @@ type OnCompleteCallback = (data: {
   format: ModelFormat;
 }) => void;
 
+type OnErrorCallback = (error: Error) => void;
+
 export class ScadRenderer {
   private onStart?: OnStartCallback;
   private onComplete: OnCompleteCallback;
+  private onError?: OnErrorCallback;
   private onLog?: (chunk: string) => void;
 
   constructor({
     onStart,
     onComplete,
+    onError,
     onLog,
   }: {
     onStart?: OnStartCallback;
     onComplete: OnCompleteCallback;
+    onError?: OnErrorCallback;
     onLog?: (chunk: string) => void;
   }) {
     this.onStart = onStart;
     this.onComplete = onComplete;
+    this.onError = onError;
     this.onLog = onLog;
   }
 
@@ -42,13 +48,24 @@ export class ScadRenderer {
       .getConfiguration("openscad")
       .get<ModelFormat>("previewFormat", ModelFormat.ThreeMF);
 
-    const modelBuffer = await ScadClient.render(
-      path,
-      parameters,
-      format,
-      this.onLog,
-    );
+    try {
+      const modelBuffer = await ScadClient.render(
+        path,
+        parameters,
+        format,
+        this.onLog,
+      );
+      this.onComplete({ buffer: modelBuffer, format });
+    } catch (err) {
+      // Don't surface cancellations — they are intentional (a newer render
+      // superseded this one) and should not be shown as errors to the user.
+      if (err instanceof Error && err.message === "Render cancelled") {
+        return;
+      }
 
-    this.onComplete({ buffer: modelBuffer, format });
+      if (this.onError) {
+        this.onError(err instanceof Error ? err : new Error(String(err)));
+      }
+    }
   }
 }

--- a/src/extension/services/ScadWatcher.ts
+++ b/src/extension/services/ScadWatcher.ts
@@ -25,14 +25,21 @@ export class FileWatcher {
       this.watcher.close();
     }
 
+    // ignoreInitial: true prevents chokidar from firing an "add" event for
+    // a file that already exists when the watcher starts. Without this fix,
+    // chokidar fires "add" AND we call handleFileChange() explicitly below,
+    // so the onChange callback fires twice in rapid succession. The first
+    // render gets killed immediately (producing "Render cancelled") and the
+    // second runs into a torn-down state (producing "exit code 1").
     this.watcher = watch(path, {
       persistent: true,
-      ignoreInitial: false,
+      ignoreInitial: true,
     });
 
     this.watcher.on("add", (path) => this.handleFileChange(path));
     this.watcher.on("change", (path) => this.handleFileChange(path));
 
+    // Read the file once immediately so the session has content on startup.
     await this.handleFileChange(path);
   }
 

--- a/src/extension/views/ScadWebviewPanel.ts
+++ b/src/extension/views/ScadWebviewPanel.ts
@@ -144,6 +144,43 @@ export class ScadWebviewPanel {
       this.disposables,
     );
 
+    this.session.onRenderError(
+      (err) => {
+        // Clear the loading spinner so the webview doesn't hang indefinitely.
+        this.postMessage({
+          type: "loadingState",
+          loading: false,
+        });
+
+        // Show the error in the VS Code notification area and direct the user
+        // to the output channel for the full OpenSCAD stderr output.
+        const msg = err.message;
+        window.showErrorMessage(
+          `OpenSCAD render failed: ${msg.split("\n")[0]}`,
+          "Show Output"
+        ).then((choice) => {
+          if (choice === "Show Output") {
+            // The output channel is named "OpenSCAD Preview" — reveal it.
+            // We can't reference it directly here, but the user can open it
+            // from View > Output and select "OpenSCAD Preview".
+            window.showInformationMessage(
+              'Open the Output panel and select "OpenSCAD Preview" from the dropdown to see the full error.'
+            );
+          }
+        });
+
+        // Also forward the first line of the error to the webview log panel.
+        if (this.isWebviewReady) {
+          this.postMessage({
+            type: "log",
+            message: `ERROR: ${msg}`,
+          });
+        }
+      },
+      null,
+      this.disposables,
+    );
+
     this.session.onParametersChanged(
       ({ parameters, parameterSets, activeSetName, overrides }) => {
         if (this.isWebviewReady) {


### PR DESCRIPTION
## Summary

This PR resolves a class of rendering failures related to parameter validation and wires up a complete error reporting path from OpenSCAD's process output to the VS Code UI.

### Root cause fix: expression variables corrupting `-D` args

The core bug (related to issue #47): `ScadParser` previously classified any variable value that wasn't a boolean or a bare number as a `string`. This caused expression-valued variables like:

```scad
shelf_depth = device_depth + surface_thickness + width_extra_clearance;
inner_width_w_clearance = device_width + width_extra_clearance;
```

...to be emitted as string parameters and passed to OpenSCAD as:

```
-D shelf_depth="device_depth + surface_thickness + width_extra_clearance"
```

OpenSCAD received a string literal instead of the computed value, breaking every downstream use of those variables. Files using BOSL2 or similar libraries with derived variables failed entirely. The fix: `parseVariableValue` now returns `null` for anything that isn't a boolean, numeric, or explicitly quoted string literal. Expression-valued variables are skipped — OpenSCAD computes them from the source file as intended.

### Error propagation

Previously, render errors were swallowed: `ScadRenderer` had no error callback, `ScadSession` had no error event, and `ScadWebviewPanel` had no handler. The loading spinner would hang indefinitely on failure. This PR wires the full path: `ScadClient` rejection → `ScadRenderer.onError` → `ScadSession.onRenderError` → `ScadWebviewPanel`, which clears the spinner, shows a notification with a "Show Output" action, and forwards the error to the webview log panel.

### Windows-specific fixes

- **Kill detection**: On Windows, `SIGTERM` is not sent when a child process is killed — the process exits with code 1 and a null signal with no stderr. Added a heuristic to detect this case and reject with `"Render cancelled"` instead of surfacing it as an error.
- **Double-render on startup**: Chokidar was firing an `"add"` event immediately on watch start (`ignoreInitial: false`), racing with the explicit `handleFileChange()` call. The first render was immediately cancelled, and the second hit a partially torn-down state. Fixed by setting `ignoreInitial: true`.
- **Build task**: Changed the VS Code compile task from `type: "npm"` to `type: "shell"` with an explicit `cwd` and `npm --prefix` to ensure reliable execution regardless of terminal working directory on Windows.

### Additional

- All OpenSCAD stderr is now streamed to the output channel immediately as it arrives, not only on failure.
- The full command is logged before spawn for easier debugging.
- Error rejections include the full stderr output and the executable path.
- Replaced deprecated `vscode-test` with `@vscode/test-electron`; updated `@types/vscode` to 1.120.0 to cure vulnerabilities and deprecation notices (vscode-test and several dependencies were deprecated).

## Test plan

- [ ] Open a `.scad` file with expression-derived variables (e.g. `shelf_depth = a + b + c`) — confirm it renders correctly without those variables appearing in the customizer or being passed as `-D` args
- [ ] Open a `.scad` file that uses an external library (e.g. BOSL2) — confirm no `WARNING: undefined operation (string + number)` errors
- [ ] Introduce a deliberate syntax error — confirm the loading spinner clears, an error toast appears with "Show Output", and the Output panel shows the full OpenSCAD stderr
- [ ] Open a file, make a rapid series of changes — confirm only the latest render completes and no "Render cancelled" errors appear in the UI
- [ ] Confirm only one "OpenSCAD Preview" entry exists in the VS Code Output dropdown
- [ ] On Windows: kill a render mid-flight by editing the file — confirm no spurious error notification